### PR TITLE
Revert ruby version and set rails version to 7.0

### DIFF
--- a/nepali_calendar.gemspec
+++ b/nepali_calendar.gemspec
@@ -20,8 +20,8 @@ Gem::Specification.new do |spec|
   spec.executables            = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths          = ['lib']
 
-  spec.required_ruby_version  = '>= 3.1.0'
-  spec.add_dependency "rails", "~> 7.2.0"
+  spec.required_ruby_version  = '>= 2.7.2'
+  spec.add_dependency "rails", "~> 7.0"
 
   spec.add_development_dependency 'bundler', '~> 2.0'
   spec.add_development_dependency 'rake', '~> 12.2'


### PR DESCRIPTION
This PR: 
- Reverts ruby version back to 2.7.2
- Updates rails version to 7.0. This change will allow the gem to work on all the rails version equal or greater than 7.0 until a major version is released.