### PR TITLE
update ruby and rails version

### DIFF
--- a/nepali_calendar.gemspec
+++ b/nepali_calendar.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |spec|
   spec.require_paths          = ['lib']
 
   spec.required_ruby_version  = '>= 2.7.2'
-  spec.add_dependency "rails", "~> 7.0"
+  spec.add_dependency "rails", ">= 7.0"
 
   spec.add_development_dependency 'bundler', '~> 2.0'
   spec.add_development_dependency 'rake', '~> 12.2'


### PR DESCRIPTION
Update:
- support rails version greater than 7.0

This is required to support rails 8. 